### PR TITLE
Adding support for Hogan (.hgn)

### DIFF
--- a/HTMLMustache.sublime-settings
+++ b/HTMLMustache.sublime-settings
@@ -1,5 +1,3 @@
 {
-    "extensions": [
-        "mustache"
-    ]
+    "extensions": ["hgn", "mustache"]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 SublimeHTMLMustache
 ===================
 
-Adds HTML [Mustache][2] as a language to [Sublime Text 2][1], with snippets. Syntax file obtained from [mwunsch's sublime repo][3]
+Adds HTML [Mustache][2] as a language to [Sublime Text 2][1], with snippets. Syntax file obtained from [mwunsch's sublime repo][3].  
+
+> It does support [`.mustache`](http://mustache.github.io) and [`.hgn`](http://twitter.github.io/hogan.js) files.
+
 
 How to Use
 ==========

--- a/Syntaxes/HTMLMustache.tmLanguage
+++ b/Syntaxes/HTMLMustache.tmLanguage
@@ -5,6 +5,7 @@
     <key>fileTypes</key>
     <array>
         <string>mustache</string>
+        <string>hgn</string>
     </array>
     <key>foldingStartMarker</key>
     <string>(?x)
@@ -52,6 +53,6 @@
         </dict>
     </array>
     <key>scopeName</key>
-    <string>text.html.mustache</string>
+    <string>txt.html.mustache, text.html.hgn</string>
 </dict>
 </plist>

--- a/Syntaxes/HTMLMustache.tmPreferences
+++ b/Syntaxes/HTMLMustache.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>Preferences</string>
     <key>scope</key>
-    <string>text.html.mustache</string>
+    <string>text.html.mustache, text.html.hgn</string>
     <key>settings</key>
     <dict>
         <key>shellVariables</key>

--- a/mustache comment.sublime-snippet
+++ b/mustache comment.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
     <tabTrigger>mc</tabTrigger>
     <description>Mustache Comment</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache if else.sublime-snippet
+++ b/mustache if else.sublime-snippet
@@ -9,5 +9,5 @@ ${3:what_to_do_if_not}
 ]]></content>
     <tabTrigger>mie</tabTrigger>
     <description>Mustache If/Else</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache if.sublime-snippet
+++ b/mustache if.sublime-snippet
@@ -3,5 +3,5 @@
 \{\{# ${1:variable} \}\}${2:what_to_do}\{\{/ ${1:variable} \}\}]]></content>
     <tabTrigger>mi</tabTrigger>
     <description>Mustache If</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache loop.sublime-snippet
+++ b/mustache loop.sublime-snippet
@@ -6,5 +6,5 @@ ${2:loop code}
 ]]></content>
     <tabTrigger>ml</tabTrigger>
     <description>Mustache Loop</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache not block.sublime-snippet
+++ b/mustache not block.sublime-snippet
@@ -5,5 +5,5 @@ ${2:what_to_do_if_not}
 \{\{/ ${1:variable} \}\}]]></content>
     <tabTrigger>mnb</tabTrigger>
     <description>Mustache Not Block</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache not.sublime-snippet
+++ b/mustache not.sublime-snippet
@@ -3,5 +3,5 @@
 \{\{^ ${1:variable} \}\}${2:what_to_do_if_not}\{\{/ ${1:variable} \}\}]]></content>
     <tabTrigger>mn</tabTrigger>
     <description>Mustache Not</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache partial.sublime-snippet
+++ b/mustache partial.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
     <tabTrigger>mp</tabTrigger>
     <description>Mustache Partial</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache safe variable.sublime-snippet
+++ b/mustache safe variable.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
     <tabTrigger>mvs</tabTrigger>
     <description>Mustache Variable (Safe)</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>

--- a/mustache variable.sublime-snippet
+++ b/mustache variable.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
     <tabTrigger>mv</tabTrigger>
     <description>Mustache Variable</description>
-    <scope>text.html.mustache</scope>
+    <scope>text.html.mustache, text.html.hgn</scope>
 </snippet>


### PR DESCRIPTION
Just changed the preferences to support [Hogan](http://twitter.github.io/hogan.js) files (`.hgn`).
[Hogan](http://twitter.github.io/hogan.js) is a templating engine created by Twitter and follows the same [syntax/specification](http://mustache.github.io/mustache.5.html) of [Mustache](http://mustache.github.io).
