### PR TITLE
Remove trailing comma

### DIFF
--- a/HTMLMustache.sublime-settings
+++ b/HTMLMustache.sublime-settings
@@ -3,6 +3,6 @@
         "hgn",
         "hjs",
         "mst",
-        "mustache",
+        "mustache"
     ]
 }


### PR DESCRIPTION
Sublime Text 2 was complaining about the trailing comma on the last line. I was getting this error:

> Error trying to parse settings: Trailing comma before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/HTML Mustache/HTMLMustache.sublime-settings:7:5

Removing the comma seemed to make it happy.